### PR TITLE
rewrite GenAI::Language::OpenAI#complete method

### DIFF
--- a/lib/gen_ai/language/open_ai.rb
+++ b/lib/gen_ai/language/open_ai.rb
@@ -23,7 +23,9 @@ module GenAI
       end
 
       def complete(prompt, options = {})
-        chat_request build_completion_options(prompt, options)
+        parameters = build_completion_options(prompt, options)
+
+        chat_request parameters
       end
 
       def chat(messages, options = {}, &block)


### PR DESCRIPTION
I think the code line `chat_request build_completion_options(prompt, options)` contains 2 method in the same line is a little difficult to maintain. I think split into variable is a better way to write the code.