### PR TITLE
add more specific instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,18 @@ This gem is compatible with Ruby 3.1 or greater.
 
 ## Usage
 
-Require it in you code:
+If you use OpenAI, add:
 
 ```ruby
 require 'gen_ai'
+require 'openai'
 ```
+If you use Google Gemini, add:
 
+```ruby
+require 'gen_ai'
+require 'gemini-ai'
+```
 ### Feature support
 
 ✅ - Supported | ❌ - Not supported | 🛠️ - Work in progress


### PR DESCRIPTION
If calling only `require 'open-ai'`, the problem raise is cannot find `::OpenAI` or `::Gemini`. So adding this to README